### PR TITLE
Use unversioned symbol for realpath() (dlsym vs dlvsym)

### DIFF
--- a/installwatch.c
+++ b/installwatch.c
@@ -430,7 +430,7 @@ static void initialize(void) {
 	true_opendir     = dlsym(handle, "opendir");
 	true_readdir     = dlsym(handle, "readdir");
 	true_readlink    = dlsym(handle, "readlink");
-	true_realpath    = dlvsym(handle, "realpath", "GLIBC_2.3");
+	true_realpath    = dlsym(handle, "realpath");
 	true_rename      = dlsym(handle, "rename");
 	true_rmdir       = dlsym(handle, "rmdir");
 	true_scandir     = dlsym(handle, "scandir");


### PR DESCRIPTION
This version requirement was breaking ranlib and gcc when installwatch was invoked, so use the unversioned dlsym() to load the realpath function instead of dlvsym().