### PR TITLE
Fix utimensat() to use instw_setpathrel().

### DIFF
--- a/installwatch.c
+++ b/installwatch.c
@@ -3463,7 +3463,7 @@ int utimensat (int dirfd, const char *pathname, const struct timespec times[2], 
 	}
 
   instw_new(&instw);
-  instw_setpath(&instw, pathname);
+  instw_setpathrel(&instw, dirfd, pathname);
 
 #if DEBUG
   instw_print(&instw);


### PR DESCRIPTION
This blew up in installing libmnl, at least for me. It installs man pages from a subdirectory and cp enters the target directory to fix the times, installwatch looked for the file in  the current working directory.

Funny how that triggered so seldomly, over all these years.

(Btw.: I stumbled upon this after disabling Sourcemage's castfs, which mysteriously failed for cython install. Installwatch as fallback, also for a future castfs replacement using overlayfs, is good to have … with different bugs;-)